### PR TITLE
Fixed some login issues involving the check for hardware ID issues, should be fixed now

### DIFF
--- a/account-api/account-system/account-system-logic-index.js
+++ b/account-api/account-system/account-system-logic-index.js
@@ -139,16 +139,22 @@ const getHardwareID = async () => {
       .map(iface => iface.mac)
       .join('');
 
-    // Get disk serial (Windows specific)
+    // Get disk serial (Windows & Linux specific)
     let diskSerial = '';
     if (process.platform === 'win32') {
       try {
         diskSerial = execSync('wmic diskdrive get SerialNumber').toString().trim();
       } catch (err) {
-        console.error('Error getting disk serial:', err);
+        console.error('Error getting disk serial for your Windows device:', err);
+      }
+    } else if (process.platform === 'linux') {
+      try {
+        diskSerial = execSync('cat /sys/class/dmi/id/product_uuid').toString().trim();
+      } catch (err) {
+        console.error('Error getting disk serial for your Linux device:', err);
       }
     } else {
-      diskSerial = execSync('cat /sys/class/dmi/id/product_uuid').toString().trim();
+      console.error('Unsupported platform:', process.platform);
     }
 
     // Combine hardware identifiers


### PR DESCRIPTION
Fixed a issue when logging in, the check for hardware ID system fails to check and gives back the ("error": "Hardware ID could not be found") error, should work now.